### PR TITLE
fix(prometheus-metrics): Fix metric type of DNS request latency

### DIFF
--- a/charts/kubebridge/Chart.yaml
+++ b/charts/kubebridge/Chart.yaml
@@ -24,13 +24,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.2.0"
+appVersion: "v0.2.1"
 
 dependencies:
   - name: redis

--- a/charts/kubebridge/README.md
+++ b/charts/kubebridge/README.md
@@ -12,7 +12,7 @@ This document provides a reference for the configurable values in the `values.ya
 | `global.fullnameOverride`     | string | `""`                | Fully override common.names.fullname template.                                     |
 | `global.commonPodAnnotations` | object | See `values.yaml`   | Add annotations to pods of Sync and DNS components                                 |
 | `global.image.repository`     | string | `hayk96/kubebridge` | The Docker image repository.                                                       |
-| `global.image.tag`            | string | `v0.2.0`            | The Docker image tag.                                                              |
+| `global.image.tag`            | string | `v0.2.1`            | The Docker image tag.                                                              |
 
 ### Sync parameters
 

--- a/charts/kubebridge/values.yaml
+++ b/charts/kubebridge/values.yaml
@@ -12,7 +12,7 @@ global:
   image:
     repository: hayk96/kubebridge
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v0.2.0"
+    tag: "v0.2.1"
 
 sync:
   replicaCount: 1

--- a/src/dns/dns_server.py
+++ b/src/dns/dns_server.py
@@ -119,12 +119,6 @@ class DNSServer:
                         "lookup_time_ms": (exec_time * 1000).__round__(3)
                     })
 
-                    metrics.kubebridge_dns_requests.labels(
-                        app_name="dns",
-                        record_type=dns.QTYPE[request.q.qtype],
-                        record_name=request.q.qname,
-                        record_ip=reply.short()).inc()
-
                     metrics.kubebridge_dns_lookup_time_seconds.labels(
                         app_name="dns",
                         record_type=dns.QTYPE[request.q.qtype],

--- a/src/dns/dns_server.py
+++ b/src/dns/dns_server.py
@@ -129,7 +129,7 @@ class DNSServer:
                         app_name="dns",
                         record_type=dns.QTYPE[request.q.qtype],
                         record_name=request.q.qname,
-                        record_ip=reply.short()).set(exec_time)
+                        record_ip=reply.short()).observe(exec_time)
 
         except KeyboardInterrupt:
             logger.error("Server shutting down...")

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -1,4 +1,4 @@
-from prometheus_client import Gauge, Counter, disable_created_metrics
+from prometheus_client import Gauge, Counter, Summary, disable_created_metrics
 
 disable_created_metrics()
 
@@ -14,6 +14,6 @@ kubebridge_dns_requests = Counter("kubebridge_dns_requests",
                                   "Total count of DNS requests processed for domain records",
                                   labelnames=["app_name", "record_type", "record_name", "record_ip"])
 
-kubebridge_dns_lookup_time_seconds = Gauge("kubebridge_dns_lookup_time_seconds",
-                                           "Time taken to resolve DNS queries in seconds",
-                                           labelnames=["app_name", "record_type", "record_name", "record_ip"])
+kubebridge_dns_lookup_time_seconds = Summary("kubebridge_dns_lookup_time_seconds",
+                                             "Time taken to resolve DNS queries in seconds",
+                                             labelnames=["app_name", "record_type", "record_name", "record_ip"])

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -1,4 +1,4 @@
-from prometheus_client import Gauge, Counter, Summary, disable_created_metrics
+from prometheus_client import Gauge, Summary, disable_created_metrics
 
 disable_created_metrics()
 
@@ -9,10 +9,6 @@ kubebridge_sync_services = Gauge("kubebridge_sync_services",
 kubebridge_sync_services_count = Gauge("kubebridge_sync_services_count",
                                        "Number of services synchronized by the KubeBridge Sync component",
                                        labelnames=["app_name"])
-
-kubebridge_dns_requests = Counter("kubebridge_dns_requests",
-                                  "Total count of DNS requests processed for domain records",
-                                  labelnames=["app_name", "record_type", "record_name", "record_ip"])
 
 kubebridge_dns_lookup_time_seconds = Summary("kubebridge_dns_lookup_time_seconds",
                                              "Time taken to resolve DNS queries in seconds",


### PR DESCRIPTION
**1. What this PR does / why we need it:**

- Changed metric type of the `kubebridge_dns_lookup_time_seconds` from `Gauge` to `Summay` as Summary is one of the best options for calculating latencies
- The metric `kubebridge_dns_requests` has been removed as the `kubebridge_dns_lookup_time_seconds` with type `Summary` already exports the counts (a Counter) to eliminate high cardinality of the exported metrics
- Bump app and chart version to `0.2.1`

**2. Make sure that you've checked the boxes below before you submit PR:**
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://gcc.gnu.org/dco.html) signed
- [x] No conflict with the main branch.
- [x] Version updated in code, docs, and metadata.
